### PR TITLE
Add some config to custom SMTP server

### DIFF
--- a/arbiter/actions.py
+++ b/arbiter/actions.py
@@ -296,9 +296,14 @@ def send_email(subject, html_message, to, bcc, sender, image_attachment=None,
 
     # Send the message
     if email["bcc"] or email["to"]:
-        mail_server = cfg.email.mail_server 
+        mail_server = cfg.email.mail_server
+        smtp_starttls = cfg.email.smtp_starttls
+        smtp_passwd = cfg.email.smtp_passwd
         try:
             with smtplib.SMTP(mail_server) as smtp:
+                if (smtp_starttls == True and smtp_passwd != ''):
+                    smtp.starttls()  # Start TLS encryption
+                    smtp.login(email["From"], smtp_passwd)  # Login                
                 smtp.send_message(email)
         except Exception as err:
             logger.debug(err)

--- a/arbiter/cfgparser.py
+++ b/arbiter/cfgparser.py
@@ -379,6 +379,8 @@ base_validation_config = {
     "email": {
         "email_domain": ValidationProtocol(str),
         "from_email": ValidationProtocol(str),
+        "smtp_passwd": ValidationProtocol(str,default_value=""),
+        "smtp_starttls": ValidationProtocol(bool,default_value=False),
         "admin_emails": ValidationProtocol(list, all_are_str),
         "mail_server": ValidationProtocol(str, can_ping),
         "keep_plots": ValidationProtocol(bool),

--- a/etc/config.toml
+++ b/etc/config.toml
@@ -21,6 +21,8 @@ time_to_min_bad = 1800  # 30 minutes
 [email]
 email_domain = 'organization.edu'  # Used for a generic email addr integration in integrations.py
 from_email = 'noreply+arbiter@organization.edu'
+smtp_passwd = '' # Used to login
+smtp_starttls = true # default false
 admin_emails = ['john.doe@organization.edu']
 mail_server = '0.0.0.0'
 keep_plots = false


### PR DESCRIPTION
Add two SMTP parameters to enable login for mail servers, including the starttls parameter and a login requirement.