### PR TITLE
fix: only attempt to read one byte from smaps when checking permissions

### DIFF
--- a/arbiter/permissions.py
+++ b/arbiter/permissions.py
@@ -60,8 +60,8 @@ def has_pss_permissions(logger_instance=startup_logger):
     """
     logger_instance.debug("Checking root or CAP_SYS_PTRACE capability")
     try:
-        with open("/proc/1/smaps", "r") as smaps:
-            smaps.readlines()
+        with open("/proc/1/smaps", "rb") as smaps:
+            smaps.read(1)
         return True
     except PermissionError:
         return False


### PR DESCRIPTION
Very small optimization, but when checking if we can read the smaps file, don't read the whole thing. 